### PR TITLE
coerce types when parsing from a batch set operation

### DIFF
--- a/spec/fixtures/testing_broken.json
+++ b/spec/fixtures/testing_broken.json
@@ -1,0 +1,6 @@
+{
+  "int": "123",
+  "string": "two",
+  "bool": "true",
+  "float": "1.2"
+}

--- a/spec/setup_spec.cr
+++ b/spec/setup_spec.cr
@@ -61,6 +61,26 @@ module Biplane
       it "can get multiple values" do
         setup.gets("test", "hello").should eq([1, nil])
       end
+
+      context "type coercion assumptions" do
+        broken = Setup.new("./spec/fixtures/testing_broken.json")
+
+        it "returns ints if a string is all digits" do
+          broken.get("int").should eq 123
+        end
+
+        it "returns floats if a string is all digits with a single decimal" do
+          broken.get("float").should eq 1.2
+        end
+
+        it "returns booleans is true or false" do
+          broken.get("bool").should be_true
+        end
+
+        it "returns a string otherwise" do
+          broken.set("string", "two")
+        end
+      end
     end
 
     describe "typed getters" do
@@ -123,6 +143,43 @@ module Biplane
       it "can set multiple and retains types when fetching" do
         setup.set(["hello=max", "one=1", "nox=true"])
         setup.gets("hello", "one", "nox").should eq(["max", 1, true])
+      end
+
+      context "type coercion assumptions" do
+        it "returns ints if a string is all digits" do
+          setup.set("coerce", "123")
+          setup.get("coerce").should eq 123
+        end
+
+        it "returns floats if a string is all digits with a single decimal" do
+          setup.set("coerce", "123.4")
+          setup.get("coerce").should eq 123.4
+        end
+
+        it "returns booleans is true or false" do
+          setup.set("coerce", "true")
+          setup.get("coerce").should be_true
+
+          setup.set("coerce", "false")
+          setup.get("coerce").should be_false
+        end
+
+        it "returns a string otherwise" do
+          setup.set("coerce", "not coercable")
+          setup.get("coerce").should eq "not coercable"
+        end
+
+        it "passes thru other types" do
+          setup.set("coerce", 1.to_i64)
+          setup.get("coerce").should eq 1
+        end
+
+        it "passes thru other types" do
+          setup.set("coerce", true)
+          setup.get("coerce").should eq true
+        end
+
+        setup.remove("coerce")
       end
     end
 

--- a/spec/setup_spec.cr
+++ b/spec/setup_spec.cr
@@ -120,9 +120,9 @@ module Biplane
         setup.get("hello") { "not this" }.should eq "or this"
       end
 
-      it "can set multiple" do
-        setup.set(["hello=max", "fellow=wax"])
-        setup.gets("hello", "fellow").should eq(["max", "wax"])
+      it "can set multiple and retains types when fetching" do
+        setup.set(["hello=max", "one=1", "nox=true"])
+        setup.gets("hello", "one", "nox").should eq(["max", 1, true])
       end
     end
 
@@ -138,9 +138,10 @@ module Biplane
       end
 
       it "can remove multiple" do
-        setup.remove("hello", "fellow")
+        setup.remove("hello", "one", "nox")
         setup.set?("hello").should be_false
-        setup.set?("fellow").should be_false
+        setup.set?("one").should be_false
+        setup.set?("nox").should be_false
       end
     end
 

--- a/src/biplane/setup.cr
+++ b/src/biplane/setup.cr
@@ -77,7 +77,7 @@ module Biplane
     end
 
     def set(key, value)
-      @values[key.to_s] = value
+      @values[key.to_s] = parse_values(value)
       sync
 
       value
@@ -98,6 +98,25 @@ module Biplane
 
     private def sync
       File.write @path, @values.to_pretty_json
+    end
+
+    private def parse_values(item : String)
+      case item
+      when .== "true"
+        true
+      when .== "false"
+        false
+      when .match /^\d+$/
+        item.to_i64
+      when .match /^\d+.\d+$/
+        item.to_f64
+      else
+        item.to_s
+      end
+    end
+
+    private def parse_values(item)
+      item
     end
   end
 end

--- a/src/biplane/setup.cr
+++ b/src/biplane/setup.cr
@@ -61,7 +61,7 @@ module Biplane
     end
 
     def get(key, default = nil)
-      config.fetch(key.to_s, default) as Terminals
+      parse_values config.fetch(key.to_s, default)
     end
 
     def get(key, default = nil, &block)


### PR DESCRIPTION
Fixes issue #6 

Caused when batch setting `.biplane` config and types were set always as strings.

This likely will not fix broken `.biplane` files and so we should likely also correct for this on read and not solely on set operations.
